### PR TITLE
セリフの色を変更できるようにしたのだ

### DIFF
--- a/sample.xml
+++ b/sample.xml
@@ -13,16 +13,16 @@
     <voiceconfig id="tsumugi" backend="voicevox">
       <voicevoxconfig id="8" />
     </voiceconfig>
-    <characterconfig name="char1" voice-id="metan" />
-    <characterconfig name="char2" voice-id="zundamon" />
+    <characterconfig name="char1" voice-id="metan" serif-color="#E14D2A" />
+    <characterconfig name="char2" voice-id="zundamon" serif-color="#379237" />
     <characterconfig name="char2_hiso" voice-id="zundamon-hisohiso" />
     <characterconfig name="char3" voice-id="tsumugi" />
     <assets>
       <face id="zunda1" file="zunda1.png" />
     </assets>
   </meta>
-  <scenary bg="black" />
   <dialogue backgroundImage="">
+  <!-- TODO: assetのパスをhtmlからのパスではなくxmlからのパスにする、asset: schemeの導入 -->
     <say by="char1">このXMLファイルは、zmmの動作を説明するためのサンプルです。</say>
     <say by="char1">キャラクター1の音声です。</say>
     <say by="char2">そして、キャラクター2の音声です。</say>
@@ -30,5 +30,7 @@
     登場するキャラクターの音声を切り替えることができます。すごいね。</say>
     <say by="char1" speed="1.2">スピード属性を使うことにより、その箇所の読み上げ速度を上げることができます。</say>
     <say by="char2_hiso">キャラクターに用意されているひそひそ声で読み上げることも可能なのだ。</say>
+    <say by="char2">セリフの色は、キャラクターコンフィグで設定することで、そのキャラクターのすべてのセリフに適用されるのだ。</say>
+    <say by="char2" serif-color="#DD5500">このように、個々の要素にパラメータを指定することでもセリフの色をコントロールできるのだ。</say>
   </dialogue>
 </content>

--- a/src/main/scala/com/github/windymelt/zmm/Cli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Cli.scala
@@ -126,7 +126,8 @@ final class Cli
     val characterConfigList = elem \ "meta" \ "characterconfig"
     val characterConfigMap = characterConfigList.map { cc =>
       val name = cc \@ "name"
-      name -> domain.model.CharacterConfig(name, cc \@ "voice-id")
+      val defaultSerifColor = Some(cc \@ "serif-color").filterNot(_.isEmpty())
+      name -> domain.model.CharacterConfig(name, cc \@ "voice-id", defaultSerifColor)
     }.toMap
 
     val defaultBackgroundImage =

--- a/src/main/twirl/sample.scala.html
+++ b/src/main/twirl/sample.scala.html
@@ -3,7 +3,7 @@
     <body style="background-color: darkblue; @ctx.backgroundImageUrl.map(url => s"background-image: url('${url}');" ).getOrElse("") background-size: 100%;">
         <img alt="zunda" src="../../assets/zunda.png" style="position: fixed; height: 80%; bottom:0px; right: 0%;" />
         <div style="background-color: rgba(0,0,0,0.5); position: fixed; left: 0px; bottom: 0px; height: 40%; width: 100%; font-size: 64pt;">
-            <div style="padding:0 1em 0 1em; font-family: Corporate Logo ver3; font-weight: 800; color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">@serif</div>
+            <div style="padding:0 1em 0 1em; font-family: Corporate Logo ver3; font-weight: 800; color: white; -webkit-text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")}; text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")};">@serif</div>
             <!-- <div style="padding:0 1em 0 1em; font-family: Corporate Logo ver3; font-weight: 800; color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">
                 TODO: SVG Textには今のところ折り返し機能が無いのだ そのかわり綺麗なテキスト縁取りが利用できるのだ
                 <svg style="width: 100%">


### PR DESCRIPTION
## やりたい

これまでは、セリフの色を変更することができなかった。

一般に、発話しているキャラクターによってセリフの色を変更することはよく行われている慣習であるから、zmmでも優先度高く対応させたい。

また、個々のセリフについて毎回設定するのではなく、冒頭のキャラクターコンフィグでデフォルトの色を定めると、特に変更しない限りその色が使われるようになっていてほしい。

## やった

- デフォルトコンテキストを導出するさいに、`characterconfig`タグで設定されている`serif-color`をそのキャラクターのセリフのデフォルト色とするようにした
- 個々の`say`要素について、`serif-color`を設定することでコンテキストを導出できるようにした
- コンテキストをもとに、テンプレートがその色を認識して反映させるようにした
- サンプルを更新した