### PR TITLE
辞書登録メカニズムこわれてたので直した

### DIFF
--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/VoiceVox.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/VoiceVox.scala
@@ -83,7 +83,7 @@ trait VoiceVoxComponent {
         .fromString("http://localhost:50021/user_dict_word")
         .map(
           _.copy(
-            query = org.http4s.Query.fromMap(Map("surface" -> Seq(word), "pronounciation" -> Seq(pronounce), "accent_type" -> Seq(lowerPoint.toString)))
+            query = org.http4s.Query.fromMap(Map("surface" -> Seq(word), "pronunciation" -> Seq(pronounce), "accent_type" -> Seq(lowerPoint.toString)))
           )
         )
 
@@ -93,7 +93,7 @@ trait VoiceVoxComponent {
         headers = Headers("Content-Type" -> "application/json"),
       )
 
-      IO.unit
+      c.successful(req) *> IO.unit
     }
 
     private lazy val client = {


### PR DESCRIPTION
#6 が壊れていたので直した。

- query parameterのkeyをまちがえていたので直した
- クエリを作るだけで終了して実際は呼び出せていなかったのを直した