### PR TITLE
簡易的に補足情報の表示ができるようにする

### DIFF
--- a/sample.xml
+++ b/sample.xml
@@ -18,10 +18,11 @@
     <characterconfig name="char2_hiso" voice-id="zundamon-hisohiso" tachie-url="../../assets/zunda.png" />
     <characterconfig name="char3" voice-id="tsumugi" tachie-url="../../assets/tsumugi.png" />
     <dict pronounce="ゼットエムエ_ム">zmm</dict>
+    <dict pronounce="モチー_フ">motif</dict>
   </meta>
   <dialogue backgroundImage="">
   <!-- TODO: assetのパスをhtmlからのパスではなくxmlからのパスにする、asset: schemeの導入 -->
-    <say by="char1">このXMLファイルは、zmmの動作を説明するためのサンプルです。</say>
+    <say by="char1" motif="ここには解説を表示できます">このXMLファイルは、zmmの動作を説明するためのサンプルです。</say>
     <say by="char1">キャラクター1の音声です。</say>
     <say by="char2">そして、キャラクター2の音声です。</say>
     <say by="char3">このように、XMLタグの属性によって、
@@ -29,6 +30,8 @@
     <say by="char1" speed="1.2">スピード属性を使うことにより、その箇所の読み上げ速度を上げることができます。</say>
     <say by="char2_hiso">キャラクターに用意されているひそひそ声で読み上げることも可能なのだ。</say>
     <say by="char2">セリフの色は、キャラクターコンフィグで設定することで、そのキャラクターのすべてのセリフに適用されるのだ。</say>
-    <say by="char2" serif-color="#DD5500">このように、個々の要素にパラメータを指定することでもセリフの色をコントロールできるのだ。</say>
+    <say by="char2" serif-color="#DD5500">このように、
+    個々の要素にパラメータを指定することでもセリフの色をコントロールできるのだ。</say>
+    <say by="char2" motif="motif=...と書くことで補足情報を表示できるようにした">motif属性を使うことにより、補足情報を表示できるのだ。</say>
   </dialogue>
 </content>

--- a/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
+++ b/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
@@ -20,6 +20,7 @@ final case class Context(
     serifColor: Option[String] = None, // どう使うかはテンプレート依存
     tachieUrl: Option[String] = None,
     dict: Seq[(String, String, Int)] = Seq.empty,
+    additionalTemplateVariables: Map[String, String] = Map.empty,
     // TODO: BGM, fontColor, etc.
 )
 
@@ -50,7 +51,8 @@ object Context {
         speed = y.speed orElse x.speed, // 後勝ち
         serifColor = serifColor,
         tachieUrl = tachieUrl,
-        dict = y.dict |+| x.dict
+        dict = y.dict |+| x.dict,
+        additionalTemplateVariables = x.additionalTemplateVariables ++ y.additionalTemplateVariables,
       )
     }
     def empty: Context = Context.empty
@@ -77,7 +79,8 @@ object Context {
       spokenByCharacterId = firstAttrTextOf(e, "by"),
       speed = firstAttrTextOf(e, "speed"),
       serifColor = firstAttrTextOf(e, "serif-color"),
-      tachieUrl = firstAttrTextOf(e, "tachie-url")
+      tachieUrl = firstAttrTextOf(e, "tachie-url"),
+      additionalTemplateVariables = firstAttrTextOf(e, "motif").map("motif" -> _).toMap,
     )
   }
 

--- a/src/main/twirl/sample.scala.html
+++ b/src/main/twirl/sample.scala.html
@@ -1,6 +1,7 @@
 @(serif: String, ctx: com.github.windymelt.zmm.domain.model.Context)
 <html>
     <body style="background-color: darkblue; @ctx.backgroundImageUrl.map(url => s"background-image: url('${url}');" ).getOrElse("") background-size: 100%;">
+        <div style="position: fixed; left: 10%; right: 20%; top: 10%; font-size: 64pt; font-family: Corporate Logo ver3; color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">@{ctx.additionalTemplateVariables.get("motif")}</div>
         <img alt="zunda" src="@ctx.tachieUrl.getOrElse("")" style="position: fixed; height: 80%; bottom:0px; right: 0%;" />
         <div style="background-color: rgba(0,0,0,0.5); position: fixed; left: 0px; bottom: 0px; height: 40%; width: 100%; font-size: 64pt;">
             <div style="padding:0 1em 0 1em; font-family: Corporate Logo ver3; font-weight: 800; color: white; -webkit-text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")}; text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")};">@serif</div>


### PR DESCRIPTION
## やりたい

セリフの他に解説を表示したいことがほとんどであり、これをなんとかしたい

## やった

`motif`属性を設定することにより、簡易的に文字列をそのままテンプレートに出力できるようにした。あくまで簡易なので箇条書きに非対応になっているが今後なんとかしたい。

### example

```xml
<say by="char1" motif="あいさつです">こんにちは〜</say>