### PR TITLE
Mathjax

### DIFF
--- a/src/main/scala/com/github/windymelt/zmm/Cli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Cli.scala
@@ -161,7 +161,14 @@ final class Cli
       id -> (code, lang)
     } ).toMap
 
-    IO.pure(domain.model.Context(voiceConfigMap, characterConfigMap, defaultBackgroundImage, dict = dict, codes = codes))
+    val maths: Map[String, String] = (elem \ "predef" \ "math").flatMap(es => es.map { e =>
+      val math = e.text.stripLeading()
+      val id = e \@ "id"
+
+      id -> math
+    } ).toMap
+
+    IO.pure(domain.model.Context(voiceConfigMap, characterConfigMap, defaultBackgroundImage, dict = dict, codes = codes, maths = maths))
   }
 
   private def generateVideo(

--- a/src/main/scala/com/github/windymelt/zmm/Cli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Cli.scala
@@ -93,9 +93,10 @@ final class Cli
       voiceVox: VoiceVox,
       ctx: Context
   ): IO[(fs2.io.file.Path, scala.concurrent.duration.FiniteDuration)] = for {
+    actualPronunciation <- IO.pure(ctx.sic.getOrElse(sayElem.text)) // sicがない場合は元々のセリフを使う
     aq <- backgroundIndicator("Building Audio Query").use { _ =>
       // by属性がないことはないやろという想定でgetしている
-      buildAudioQuery(sayElem.text, ctx.spokenByCharacterId.get, voiceVox, ctx)
+      buildAudioQuery(actualPronunciation, ctx.spokenByCharacterId.get, voiceVox, ctx)
     }
 //    _ <- IO.println(aq)
     fixedAq <- ctx.speed map (sp =>

--- a/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
+++ b/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
@@ -33,6 +33,7 @@ final case class Context(
     additionalTemplateVariables: Map[String, String] = Map.empty,
     bgm: Option[String] = None,
     codes: Map[String, (String, Option[String])] = Map.empty, // id -> (code, lang?)
+    maths: Map[String, String] = Map.empty, // id -> LaTeX string
     sic: Option[String] = None, // 代替読みを設定できる(数式などで使う)
     // TODO: BGM, fontColor, etc.
 ) {
@@ -70,6 +71,7 @@ object Context {
         additionalTemplateVariables = x.additionalTemplateVariables ++ y.additionalTemplateVariables,
         bgm = y.bgm orElse x.bgm,
         codes = x.codes |+| y.codes, // Map の Monoid性を応用すると、同一idで書かれたコードは結合されるという好ましい特性が表われるのでこうしている。additionalTemplateVariablesに畳んでもいいかもしれない。現在のコードはadditionalTemplateVariablesに入れている
+        maths = x.maths |+| y.maths,
         sic = y.sic orElse x.sic,
       )
     }
@@ -93,7 +95,8 @@ object Context {
     val atvs = {
       val motif = firstAttrTextOf(e, "motif").map("motif" -> _)
       val code = firstAttrTextOf(e,"code").map("code" -> _)
-      Seq(motif, code).flatten.toMap
+      val math = firstAttrTextOf(e,"math").map("math" -> _)
+      Seq(motif, code, math).flatten.toMap
     }
     Context(
       voiceConfigMap = empty.voiceConfigMap, // TODO

--- a/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
+++ b/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
@@ -33,6 +33,7 @@ final case class Context(
     additionalTemplateVariables: Map[String, String] = Map.empty,
     bgm: Option[String] = None,
     codes: Map[String, (String, Option[String])] = Map.empty, // id -> (code, lang?)
+    sic: Option[String] = None, // 代替読みを設定できる(数式などで使う)
     // TODO: BGM, fontColor, etc.
 ) {
   def atv = additionalTemplateVariables // alias for template
@@ -69,6 +70,7 @@ object Context {
         additionalTemplateVariables = x.additionalTemplateVariables ++ y.additionalTemplateVariables,
         bgm = y.bgm orElse x.bgm,
         codes = x.codes |+| y.codes, // Map の Monoid性を応用すると、同一idで書かれたコードは結合されるという好ましい特性が表われるのでこうしている。additionalTemplateVariablesに畳んでもいいかもしれない。現在のコードはadditionalTemplateVariablesに入れている
+        sic = y.sic orElse x.sic,
       )
     }
     def empty: Context = Context.empty
@@ -103,6 +105,7 @@ object Context {
       tachieUrl = firstAttrTextOf(e, "tachie-url"),
       additionalTemplateVariables = atvs,
       bgm = firstAttrTextOf(e, "bgm"),
+      sic = firstAttrTextOf(e, "sic"),
     )
   }
 

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/VoiceVox.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/VoiceVox.scala
@@ -99,7 +99,7 @@ trait VoiceVoxComponent {
     private lazy val client = {
       import concurrent.duration._
       import scala.language.postfixOps
-      EmberClientBuilder.default[IO].withTimeout(5 minutes).withIdleConnectionTime(5 minutes).build
+      EmberClientBuilder.default[IO].withTimeout(10 minutes).withIdleConnectionTime(10 minutes).build
     }
   }
 }

--- a/src/main/twirl/sample.scala.html
+++ b/src/main/twirl/sample.scala.html
@@ -1,12 +1,33 @@
 @(serif: String, ctx: com.github.windymelt.zmm.domain.model.Context)
 <html>
     <body style="background-color: darkblue; @ctx.backgroundImageUrl.map(url => s"background-image: url('${url}');" ).getOrElse("") background-size: 100%;">
+    <!-- Highlight.js -->
     <link rel="stylesheet"
           href="../../default.min.css">
     <script src="../../highlight.min.js"></script>
     <script>hljs.highlightAll();</script>
+    <!-- Mathjax: TODO: あとでjsを埋め込む -->
+    <script>
+    MathJax = {
+        tex: {
+            inlineMath: [['$', '$'], ['\\(', '\\)']],
+            displayMath: [['\\[', '\\]']]
+        },
+        svg: {
+            fontCache: 'global',
+            scale: 1
+        }
+    };
+    </script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src=@{"https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"} ></script>
     <div style="position: fixed; left: 10%; right: 20%; top: 10%; font-size: 64pt; font-family: Corporate Logo ver3; color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">@{ctx.atv.get("motif")}</div>
         <div style="@{ctx.atv.get("code").map(_ => "").getOrElse("display: none; ")}position: fixed; left: 2%; right: 20%; top: 2%; font-size: 20pt;">
+            $f(x) = x^2 + \frac{e}{x}$
+            and
+            \[
+            E = mc^2
+            \]
             <pre>
             @defining(ctx.codes.get(ctx.atv.get("code").getOrElse("")).getOrElse("" -> None)) { c =>
                 <code class="@{c._2.map(l => s"lang-$l").getOrElse("")}">@c._1</code>

--- a/src/main/twirl/sample.scala.html
+++ b/src/main/twirl/sample.scala.html
@@ -22,12 +22,12 @@
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src=@{"https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"} ></script>
     <div style="position: fixed; left: 10%; right: 20%; top: 10%; font-size: 64pt; font-family: Corporate Logo ver3; color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">@{ctx.atv.get("motif")}</div>
+    <div style="@{ctx.atv.get("math").map(_ => "").getOrElse("display: none; ")}position: fixed; left: 2%; right: 20%; top: 2%; font-size: 32pt; color: rgba(238,232,213,1); background-color: rgba(7,54,66,0.9)">
+        \[
+        @ctx.maths.get(ctx.atv.get("math").getOrElse("")).getOrElse("")
+        \]
+    </div>
         <div style="@{ctx.atv.get("code").map(_ => "").getOrElse("display: none; ")}position: fixed; left: 2%; right: 20%; top: 2%; font-size: 20pt;">
-            $f(x) = x^2 + \frac{e}{x}$
-            and
-            \[
-            E = mc^2
-            \]
             <pre>
             @defining(ctx.codes.get(ctx.atv.get("code").getOrElse("")).getOrElse("" -> None)) { c =>
                 <code class="@{c._2.map(l => s"lang-$l").getOrElse("")}">@c._1</code>


### PR DESCRIPTION
数式を表示できるようにしたのだ

## やった

- `Mathjax`記法のサポート
  - `$\latex$`などというようにドルでくくると数式にできる
- `math`属性の追加
  - `code`属性と同様に、`predef`要素内に`math`要素を置くことで板書を書ける
- `sic`属性の追加
  - セリフ表示を無視して別の読みを充てる(数式を含むセリフなどで使える)