### PR TITLE
セリフのフォントをfontタグで指定できるようにする

### DIFF
--- a/sample.xml
+++ b/sample.xml
@@ -20,6 +20,7 @@
     <dict pronounce="ゼットエムエ_ム">zmm</dict>
     <dict pronounce="モチー_フ">motif</dict>
     <dict pronounce="コー_ド">code</dict>
+    <font>Corporate Logo ver3</font>
   </meta>
   <predef>
     <code id="code1" lang="scala">

--- a/src/main/scala/com/github/windymelt/zmm/Cli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Cli.scala
@@ -228,6 +228,8 @@ final class Cli
         .headOption
         .flatMap(_.attribute("url").headOption.map(_.text))
 
+    val defaultFont = (elem \ "meta" \ "font").headOption.map(_.text)
+
     // 発音調整などに使う文字列辞書。今のところVOICEVOXの発音辞書に使っている
     // (word, pronounce, accent lower point)
     val dict: Seq[(String, String, Int)] =
@@ -248,7 +250,7 @@ final class Cli
       id -> math
     } ).toMap
 
-    IO.pure(domain.model.Context(voiceConfigMap, characterConfigMap, defaultBackgroundImage, dict = dict, codes = codes, maths = maths))
+    IO.pure(domain.model.Context(voiceConfigMap, characterConfigMap, defaultBackgroundImage, dict = dict, codes = codes, maths = maths, font = defaultFont))
   }
 
   private def generateVideo(

--- a/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
+++ b/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
@@ -27,6 +27,7 @@ final case class Context(
     backgroundImageUrl: Option[String] = None,
     spokenByCharacterId: Option[String] = None,
     speed: Option[String] = Some("1.0"),
+    font: Option[String] = None,
     serifColor: Option[String] = None, // どう使うかはテンプレート依存
     tachieUrl: Option[String] = None,
     dict: Seq[(String, String, Int)] = Seq.empty,
@@ -65,6 +66,7 @@ object Context {
           y.backgroundImageUrl orElse x.backgroundImageUrl, // 後勝ち
         spokenByCharacterId = spokenByCharacterId,
         speed = y.speed orElse x.speed, // 後勝ち
+        font = y.font orElse x.font, // 後勝ち
         serifColor = serifColor,
         tachieUrl = tachieUrl,
         dict = y.dict |+| x.dict,
@@ -104,6 +106,7 @@ object Context {
       backgroundImageUrl = firstAttrTextOf(e, "backgroundImage"), // TODO: no camelCase
       spokenByCharacterId = firstAttrTextOf(e, "by"),
       speed = firstAttrTextOf(e, "speed"),
+      font = firstAttrTextOf(e, "font"),
       serifColor = firstAttrTextOf(e, "serif-color"),
       tachieUrl = firstAttrTextOf(e, "tachie-url"),
       additionalTemplateVariables = atvs,

--- a/src/main/twirl/sample.scala.html
+++ b/src/main/twirl/sample.scala.html
@@ -1,4 +1,5 @@
 @(serif: String, ctx: com.github.windymelt.zmm.domain.model.Context)
+@font() = {@ctx.font.getOrElse("sans-serif")}
 <html>
     <body style="background-color: darkblue; @ctx.backgroundImageUrl.map(url => s"background-image: url('${url}');" ).getOrElse("") background-size: 100%;">
     <!-- Highlight.js -->
@@ -21,7 +22,7 @@
     </script>
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src=@{"https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"} ></script>
-    <div style="position: fixed; left: 10%; right: 20%; top: 10%; font-size: 64pt; font-family: Corporate Logo ver3; color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">@{ctx.atv.get("motif")}</div>
+    <div style="position: fixed; left: 10%; right: 20%; top: 10%; font-size: 64pt; font-family: @font(); color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">@{ctx.atv.get("motif")}</div>
     <div style="@{ctx.atv.get("math").map(_ => "").getOrElse("display: none; ")}position: fixed; left: 2%; right: 20%; top: 2%; font-size: 32pt; color: rgba(238,232,213,1); background-color: rgba(7,54,66,0.9)">
         \[
         @ctx.maths.get(ctx.atv.get("math").getOrElse("")).getOrElse("")
@@ -36,7 +37,7 @@
         </div>
         <img alt="zunda" src="@ctx.tachieUrl.getOrElse("")" style="position: fixed; height: 80%; bottom:0px; right: 0%;" />
         <div style="background-color: rgba(0,0,0,0.5); position: fixed; left: 0px; bottom: 0px; height: 40%; width: 100%; font-size: 64pt;">
-            <div style="padding:0 1em 0 1em; font-family: Corporate Logo ver3; font-weight: 800; color: white; -webkit-text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")}; text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")};">@serif</div>
+            <div style="padding:0 1em 0 1em; font-family: @font(); font-weight: 800; color: white; -webkit-text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")}; text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")};">@serif</div>
             <!-- <div style="padding:0 1em 0 1em; font-family: Corporate Logo ver3; font-weight: 800; color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">
                 TODO: SVG Textには今のところ折り返し機能が無いのだ そのかわり綺麗なテキスト縁取りが利用できるのだ
                 <svg style="width: 100%">


### PR DESCRIPTION
`meta`要素の中に`font`タグを配置することで、スライドを通じて利用するフォントを指定できるようにした。