### PR TITLE
空のPタグで発言を分けて書けるようにした

### DIFF
--- a/sample.xml
+++ b/sample.xml
@@ -35,6 +35,11 @@ def groupReduction[E : Eq, S : Semigroup](xs: Seq[(E, S)]): Seq[(E, S)] = {
 }
       ]]>
     </code>
+    <code id="p-split" lang="xml">
+    <![CDATA[
+<say>一つめの発言<p/>二つめの発言</say>
+    ]]>
+    </code>
   </predef>
   <dialogue backgroundImage="" bgm="assets/nc282335_20%.mp3">
   <!-- TODO: assetのパスをhtmlからのパスではなくxmlからのパスにする、asset: schemeの導入 -->
@@ -51,5 +56,9 @@ def groupReduction[E : Eq, S : Semigroup](xs: Seq[(E, S)]): Seq[(E, S)] = {
     <say by="char2" motif="motif=...と書くことで補足情報を表示できるようにした">motif属性を使うことにより、補足情報を表示できるのだ。</say>
     <say by="char3" motif="bgm=...と書くことでbgmを設定できる">bgm属性を使うことで、その箇所で好きなBGMを流すこともできるよ。</say>
     <say by="char2" code="code1">code属性を使うことで、プログラミング言語のソースコードを画面に示すことができるのだ。</say>
+    <say by="char1" code="p-split">
+    同一キャラの発言は、空のpタグを使うことで分割できます。<p/>
+    同一キャラにしばらく喋ってもらいたいときに使うと、記述量を節約できます。
+    </say>
   </dialogue>
 </content>

--- a/src/test/scala/com/github/windymelt/zmm/domain/model/ContextSpec.scala
+++ b/src/test/scala/com/github/windymelt/zmm/domain/model/ContextSpec.scala
@@ -54,6 +54,19 @@ class ContextSpec extends AnyFlatSpec with Matchers {
     c.head._2.backgroundImageUrl shouldBe empty
   }
 
+  it should "split say by empty p tag" in {
+    val e = <dialogue><say motif="motif0">Hello<p/>world</say></dialogue>
+    val c = Context.fromNode(e)
+    c should have size (2)
+    c(0)._1.text shouldBe "Hello"
+    c(1)._1.text shouldBe "world"
+
+    val e0 = <dialogue><say motif="motif0">Hello</say><say motif="motif0">world</say></dialogue>
+    val c0 = Context.fromNode(e0)
+
+    c shouldEqual c0
+  }
+
   it should "recognize context propergation" in {
     val e =
       <dialogue backgroundImage="https://example.com/default.png">


### PR DESCRIPTION
というか元々そうなっていた。

同一キャラが長回しで喋る長文を毎回`say`タグで書くのが大変だったが、実は`p`タグで区切るだけで良かった。コンテキストは保存される。