### PR TITLE
Version表示用フラグを拡充する

### DIFF
--- a/src/main/scala/com/github/windymelt/zmm/Cli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Cli.scala
@@ -154,6 +154,25 @@ final class Cli
     IO.println(withColor(scala.io.AnsiColor.GREEN ++ scala.io.AnsiColor.BOLD)(zmmLogo)) >>
     IO.println(withColor(scala.io.AnsiColor.GREEN)(s"${BuildInfo.version}"))
 
+    /**
+      * ZMMのバージョンを表示する。
+      * 
+      * デバッグや問い合わせの助けとしても使う。
+      *
+      * @return IO[Unit]
+      */
+  def showVersion: IO[Unit] = 
+    IO.print("zmm ver=") >>
+    (BuildInfo.version match {
+      case s"$_-SNAPSHOT" => IO.print(withColor(scala.io.AnsiColor.YELLOW)(BuildInfo.version))
+      case _ => IO.print(withColor(scala.io.AnsiColor.GREEN)(BuildInfo.version))
+    }) >>
+    IO.print(", scalaVer=") >>
+    IO.print(withColor(scala.io.AnsiColor.GREEN)(BuildInfo.scalaVersion)) >>
+    IO.print(", sbtVer=") >>
+    IO.print(withColor(scala.io.AnsiColor.GREEN)(BuildInfo.sbtVersion)) >>
+    IO.println("")
+
   /**
     * 辞書要素を反映させる。
     *

--- a/src/main/scala/com/github/windymelt/zmm/CliOptions.scala
+++ b/src/main/scala/com/github/windymelt/zmm/CliOptions.scala
@@ -7,10 +7,12 @@ sealed trait ZmmOption
 final case class ShowCommand(target: String) extends ZmmOption // 今のところvoicevoxしか入らない
 final case class TargetFile(target: java.nio.file.Path) extends ZmmOption
 final case class InitializeCommand() extends ZmmOption
+final case class VersionFlag() extends ZmmOption
 
 object CliOptions {
   private val showCommand = Opts.subcommand(name = "show", help = "Prints information.")(Opts.argument[String]("voicevox").map(ShowCommand.apply))
   private val targetFile = Opts.argument[java.nio.file.Path](metavar = "XMLFile").map(TargetFile.apply)
   private val initCommand = Opts.subcommand(name = "init", help = "Initializes current directory as ZMM project.")(Opts.unit.map(_ => InitializeCommand()))
-  val opts: Opts[ZmmOption] = targetFile orElse showCommand orElse initCommand
+  private val versionOption = Opts.flag("version", help = "Show version", short = "v").map(_ => VersionFlag())
+  val opts: Opts[ZmmOption] = versionOption orElse targetFile orElse showCommand orElse initCommand
 }

--- a/src/main/scala/com/github/windymelt/zmm/Main.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Main.scala
@@ -11,11 +11,11 @@ import com.monovore.decline.effect.CommandIOApp
 object Main extends CommandIOApp(
   name = "zmm",
   header = "Zunda Movie Maker -- see https://www.3qe.us/zmm/doc/ for more documentation",
-  version = BuildInfo.version,
 ) {
   override def main: Opts[IO[ExitCode]] = CliOptions.opts map { o =>
     val cli = new Cli()
     o match {
+      case VersionFlag() => cli.showVersion >> IO.pure(ExitCode.Success)
       case ShowCommand(target) => target match {
         case "voicevox" => cli.showVoiceVoxSpeakers() >> IO.pure(ExitCode.Success)
         case _ => IO.println("subcommand [show] only accepts 'voicevox'. try `show voicevox`") >> IO.pure(ExitCode.Error)


### PR DESCRIPTION
使ってもらったユーザから問い合わせをもらうことがあるが、バージョン情報などを一手に表示する方法がなかった。動画変換時のロゴにもバージョンは表示されていたが、情報不足な上に使いにくいので単体で`--version`、`-v`を充実させた

- zmm自体のvesion
- scalaのversion
- sbtのversion

を表示するようにした。

Declineよくできてんな〜