### PR TITLE
ffmpegが上書きに失敗するケースに対応する

### DIFF
--- a/src/main/scala/com/github/windymelt/zmm/Cli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Cli.scala
@@ -141,8 +141,12 @@ final class Cli
 
          val reductedBgmWithDuration = groupReduction(bgmWithDuration)
 
+         // 環境によっては上書きに失敗する？ので出力ファイルが存在する場合削除する
+         val outputFile = os.pwd / "output_with_bgm.mp4"
+         os.remove(outputFile, checkExists = false)
+
          reductedBgmWithDuration.filter(_._1.isDefined).size match {
-           case 0 => IO.pure(os.move(zippedVideo, os.pwd / "output_with_bgm.mp4")) // Dirty fix. TODO: fix here
+           case 0 => IO.pure(os.move(zippedVideo, outputFile)) // Dirty fix. TODO: fix here
            case _ => ffmpeg.zipVideoWithAudioWithDuration(zippedVideo, reductedBgmWithDuration)
          }
        }

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/FFmpeg.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/FFmpeg.scala
@@ -83,7 +83,7 @@ trait FFmpegComponent {
             os.proc(ffmpegCommand, "-protocol_whitelist", "file", "-y", "-f", "concat", "-safe", "0", "-i", "artifacts/cutFile.txt", "-pix_fmt", "yuv420p", "-c:v", "libx264", "artifacts/scenes.mp4")
             .call(stdout = stdout, stderr = stdout, cwd = os.pwd)
         }
-        } yield os.pwd / os.RelPath("./artifacts/scenes.mp4")
+        } yield os.pwd / os.RelPath("artifacts/scenes.mp4")
     }
 
     def zipVideoWithAudioWithDuration(videoPath: os.Path, audioDurationPair: Seq[(Option[os.Path], FiniteDuration)]): IO[os.Path] = {
@@ -103,7 +103,7 @@ trait FFmpegComponent {
           os.proc(ffmpegCommand, "-y", "-i", videoPath, "-i", bgm, "-filter_complex", "[0:a][1:a]amerge=inputs=2[a]", "-map", "0:v", "-map", "[a]", "-c:v", "copy", "-ac", "2", "output_with_bgm.mp4")
           .call(stdout = stdout, stderr = stdout, cwd = os.pwd)
         }
-      } yield os.pwd / os.RelPath("output_with_bgm.mp4")
+      } yield os.pwd / "output_with_bgm.mp4"
     }
 
     def zipVideoWithAudio(video: os.Path, audio: os.Path): IO[os.Path] = for {
@@ -111,7 +111,7 @@ trait FFmpegComponent {
         os.proc(ffmpegCommand, "-y", "-r", "30", "-i", video, "-i", audio, "-c:v", "copy", "-c:a", "aac", "output.mp4")
         .call(stdout = stdout, stderr = stdout, cwd = os.pwd)
       }
-    } yield os.pwd / os.RelPath("output.mp4")
+    } yield os.pwd / "output.mp4"
 }
 
 }


### PR DESCRIPTION
ffmpegが`output_with_bgm.mp4`を上書きできないケースがあるという報告を受けたため、事前にzmm側で削除することにした。

加えて、相対パスの形式がバラバラだったので可能な範囲で統一した。