### PR TITLE
Firefoxでもスクショが取れるようにする

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,6 +7,10 @@ chromium {
   nosandbox = false
 }
 
+firefox {
+  command = "firefox"
+}
+
 ffmpeg {
   command = "ffmpeg"
 }

--- a/src/main/scala/com/github/windymelt/zmm/ChromiumCli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/ChromiumCli.scala
@@ -1,0 +1,25 @@
+package com.github.windymelt.zmm
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.implicits._
+
+class ChromiumCli extends Cli with infrastructure.ChromeScreenShotComponent {
+  val chromiumCommand =
+    sys.env.get("CHROMIUM_CMD").getOrElse(config.getString("chromium.command"))
+
+  def screenShotResource: IO[Resource[IO, ScreenShot]] = {
+    IO.println(
+      s"""[configuration] chromium command: ${chromiumCommand}"""
+    ) >> Resource
+      .eval(
+        new ChromeScreenShot(
+          chromiumCommand,
+          ChromeScreenShot.Quiet,
+          chromiumNoSandBox
+        ).pure[IO]
+      )
+      .pure[IO]
+  }
+
+}

--- a/src/main/scala/com/github/windymelt/zmm/Cli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Cli.scala
@@ -9,13 +9,12 @@ import com.github.windymelt.zmm.domain.model.Context
 import scala.concurrent.duration.FiniteDuration
 import cats.effect.std.Mutex
 
-final class Cli
+trait Cli
     extends domain.repository.FFmpegComponent
     with domain.repository.VoiceVoxComponent
     with domain.repository.ScreenShotComponent
     with infrastructure.FFmpegComponent
     with infrastructure.VoiceVoxComponent
-    with infrastructure.ChromeScreenShotComponent
     with util.UtilComponent {
 
   val zmmLogo = """ _________  ______  ___
@@ -27,10 +26,6 @@ final class Cli
 
   val voiceVoxUri =
     sys.env.get("VOICEVOX_URI") getOrElse config.getString("voicevox.apiUri")
-  val chromiumCommand =
-    sys.env.get("CHROMIUM_CMD").getOrElse(config.getString("chromium.command"))
-  val firefoxCommand =
-    sys.env.get("FIREFOX_CMD").getOrElse(config.getString("firefox.command"))
   def voiceVox: VoiceVox = new ConcreteVoiceVox(voiceVoxUri)
   def ffmpeg =
     new ConcreteFFmpeg(config.getString("ffmpeg.command"), ConcreteFFmpeg.Quiet)
@@ -38,14 +33,6 @@ final class Cli
     .get("CHROMIUM_NOSANDBOX")
     .map(_ == "1")
     .getOrElse(config.getBoolean("chromium.nosandbox"))
-  def screenShot =
-    IO(
-      new ChromeScreenShot(
-        chromiumCommand,
-        ChromeScreenShot.Quiet,
-        chromiumNoSandBox
-      )
-    )
 
   def showVoiceVoxSpeakers(): IO[Unit] = {
     import io.circe.JsonObject
@@ -137,9 +124,6 @@ final class Cli
       _ <- showLogo
       _ <- IO.println(s"""[pwd] ${System.getProperty("user.dir")}""")
       _ <- IO.println(s"""[configuration] voicevox api: ${voiceVoxUri}""")
-      _ <- IO.println(
-        s"""[configuration] chromium command: ${chromiumCommand}"""
-      )
       _ <- IO.println(s"""[configuration] ffmpeg command: ${config.getString(
           "ffmpeg.command"
         )}""")
@@ -369,29 +353,36 @@ final class Cli
       pathAndDurations: Seq[(fs2.io.file.Path, FiniteDuration)]
   ): IO[os.Path] = {
     import cats.syntax.parallel._
-    val saySeq = sayCtxPairs map { case (s, ctx) =>
-      for {
-        stream <- buildHtmlFile(s.text, ctx).map(s =>
-          fs2.Stream[IO, Byte](s.getBytes(): _*)
+
+    val shot: ScreenShot => (domain.model.Say, Context) => IO[os.Path] =
+      (ss: ScreenShot) =>
+        (s: domain.model.Say, ctx: Context) =>
+          for {
+            stream <- buildHtmlFile(s.text, ctx).map(s =>
+              fs2.Stream[IO, Byte](s.getBytes(): _*)
+            )
+            sha1Hex <- sha1HexCode(s.text.getBytes())
+            htmlFile <- writeStreamToFile(
+              stream,
+              s"./artifacts/html/${sha1Hex}.html"
+            )
+            screenShotFile <- ss.takeScreenShot(
+              os.pwd / os.RelPath(htmlFile.toString)
+            )
+          } yield screenShotFile
+
+    for {
+      ss <- screenShotResource
+      imgs <- for {
+        sceneImages <- sayCtxPairs.map { pair =>
+          ss.use { ss => shot(ss).tupled(pair) }
+        }.parSequence
+        concatenatedImages <- ffmpeg.concatenateImagesWithDuration(
+          sceneImages.zip(pathAndDurations.map(_._2))
         )
-        sha1Hex <- sha1HexCode(s.text.getBytes())
-        htmlFile <- writeStreamToFile(
-          stream,
-          s"./artifacts/html/${sha1Hex}.html"
-        )
-        ss <- screenShot
-        screenShotFile <- ss.takeScreenShot(
-          os.pwd / os.RelPath(htmlFile.toString)
-        )
-      } yield screenShotFile
-    }
-    val sceneImages =
-      saySeq.grouped(10).map(_.parSequence).toSeq.reduceRight[IO[Seq[Path]]] {
-        case (acc, io) => acc.flatMap(acc => io.map(acc ++ _))
-      }
-    sceneImages.flatMap(imgs =>
-      ffmpeg.concatenateImagesWithDuration(imgs.zip(pathAndDurations.map(_._2)))
-    )
+      } yield concatenatedImages
+
+    } yield imgs
   }
 
   private def buildAudioQuery(

--- a/src/main/scala/com/github/windymelt/zmm/FirefoxCli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/FirefoxCli.scala
@@ -1,0 +1,20 @@
+package com.github.windymelt.zmm
+
+import cats.effect.IO
+import cats.effect.std.Mutex
+import cats.effect.kernel.Resource
+
+class FirefoxCli extends Cli with infrastructure.FirefoxScreenShotComponent {
+  val firefoxCommand =
+    sys.env.get("FIREFOX_CMD").getOrElse(config.getString("firefox.command"))
+
+  def screenShotResource: IO[Resource[IO, ScreenShot]] =
+    for {
+      _ <- IO.println(
+        s"""[configuration] firefox command: ${firefoxCommand}"""
+      )
+      mx <- Mutex[IO]
+    } yield mx.lock.map { _ =>
+      new FirefoxScreenShot(firefoxCommand, FirefoxScreenShot.Quiet)
+    }
+}

--- a/src/main/scala/com/github/windymelt/zmm/domain/repository/ScreenShot.scala
+++ b/src/main/scala/com/github/windymelt/zmm/domain/repository/ScreenShot.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 
 trait ScreenShotComponent {
   type Path
-  def screenShot: ScreenShot
+  def screenShot: IO[ScreenShot]
 
   trait ScreenShot {
     def takeScreenShot(

--- a/src/main/scala/com/github/windymelt/zmm/domain/repository/ScreenShot.scala
+++ b/src/main/scala/com/github/windymelt/zmm/domain/repository/ScreenShot.scala
@@ -1,16 +1,16 @@
 package com.github.windymelt.zmm.domain.repository
 
 import cats.effect.IO
+import cats.effect.kernel.Resource
 
 trait ScreenShotComponent {
-  type Path
-  def screenShot: IO[ScreenShot]
+  def screenShotResource: IO[Resource[IO, ScreenShot]]
 
   trait ScreenShot {
     def takeScreenShot(
-        htmlFilePath: Path,
-        windowWidth: Int,
-        windowHeight: Int
-    ): IO[Path]
+        htmlFilePath: os.Path,
+        windowWidth: Int = 1920,
+        windowHeight: Int = 1080
+    ): IO[os.Path]
   }
 }

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/ChromeScreenShot.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/ChromeScreenShot.scala
@@ -3,6 +3,7 @@ package infrastructure
 
 import cats.effect.IO
 import cats.implicits._
+import cats.effect.kernel.Resource
 
 trait ChromeScreenShotComponent {
   self: domain.repository.ScreenShotComponent =>
@@ -13,8 +14,7 @@ trait ChromeScreenShotComponent {
     final object Verbose extends Verbosity
   }
 
-  type Path = os.Path
-  def screenShot: IO[ChromeScreenShot]
+  def screenShotResource: IO[Resource[IO, ScreenShot]]
 
   class ChromeScreenShot(
       chromeCommand: String,
@@ -26,10 +26,10 @@ trait ChromeScreenShotComponent {
       case ChromeScreenShot.Verbose => os.Inherit
     }
     def takeScreenShot(
-        htmlFilePath: Path,
+        htmlFilePath: os.Path,
         windowWidth: Int = 1920,
         windowHeight: Int = 1080
-    ): IO[Path] = IO.delay {
+    ): IO[os.Path] = IO.delay {
       val proc = noSandBox match {
         case true =>
           os.proc(

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/ChromeScreenShot.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/ChromeScreenShot.scala
@@ -14,7 +14,7 @@ trait ChromeScreenShotComponent {
   }
 
   type Path = os.Path
-  def screenShot: ChromeScreenShot
+  def screenShot: IO[ChromeScreenShot]
 
   class ChromeScreenShot(
       chromeCommand: String,

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/FirefoxScreenShotComponent.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/FirefoxScreenShotComponent.scala
@@ -1,0 +1,55 @@
+package com.github.windymelt.zmm
+package infrastructure
+
+import cats.effect.IO
+import cats.implicits._
+import cats.effect.std.Mutex
+
+trait FirefoxScreenShotComponent {
+  self: domain.repository.ScreenShotComponent =>
+
+  object FirefoxScreenShot {
+    sealed trait Verbosity
+    final object Quiet extends Verbosity
+    final object Verbose extends Verbosity
+  }
+
+  type Path = os.Path
+  def screenShot: IO[FirefoxScreenShot]
+
+  class FirefoxScreenShot(
+      firefoxCommand: String,
+      verbosity: FirefoxScreenShot.Verbosity,
+      mutex: Mutex[IO] // firefox outputs fixed "screenshot.png", so we cannot call it concurrently
+  ) extends ScreenShot {
+    val stdout = verbosity match {
+      case FirefoxScreenShot.Quiet   => os.Pipe
+      case FirefoxScreenShot.Verbose => os.Inherit
+    }
+    def takeScreenShot(
+        htmlFilePath: Path,
+        windowWidth: Int = 1920,
+        windowHeight: Int = 1080
+    ): IO[Path] = {
+      val absPath = htmlFilePath
+      val fileUri = s"file://$absPath"
+      println(fileUri)
+      val proc = os.proc(
+        firefoxCommand,
+        "-headless",
+        "-screenshot",
+        "-window-size",
+        s"$windowWidth,$windowHeight",
+        fileUri
+      )
+      mutex.lock.surround {
+        IO.blocking {
+          proc.call(stdout = stdout, stderr = stdout, cwd = os.pwd)
+          val outputPath = os.Path(s"${htmlFilePath}.png")
+          os.move(os.pwd / "screenshot.png", outputPath, replaceExisting = true)
+          outputPath
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- Chromeには妙なバグがあり、画面の解像度が800x600くらいになってしまうことがある(バージョンによる)


## なぜこのPRが必要になったか / Why do we need this PR

- 一時的な回避策としてFirefoxを使えるようにしたい

## なにをやったか / What I did

- Firefoxにもスクショを撮影するオプションがあるので、既存のインターフェイスを一部修正しつつ実装した。
- Firefoxは出力先ファイル名を指定できない(指定できるという情報があるが、手元で動作しなかった)ので、Mutexを使って同時に走れなくした
- Mutexを導入したのでIO型になった
- `-s firefox`オプションをつけるとFirefoxで稼動するようになる

## 補足 / Supplementary information

Firefoxは透過背景でのスクショをサポートしていないので、動画との組み合わせが今後あるなら問題になるかも