### PR TITLE
Dockerで実行時、アーティファクト生成時のownerをホスト環境のものに揃える

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val root = (project in file("."))
     dockerRepository := Some("docker.io"),
     dockerUsername := Some("windymelt"),
     dockerUpdateLatest := true,
-    mappings in Universal += file("entrypoint.sh") -> "entrypoint.sh",
+    Universal / mappings += file("entrypoint.sh") -> "entrypoint.sh",
     /* zmmではScala highlightのためにカスタムしたhighlight.jsを同梱しているが、mappingが今のところ壊れているのでDocker Imageでは直接highlight.jsをダウンロードさせる */
     dockerCommands ++= Seq(
       // Initnally, run as root. Go to protected user inside entrypoint.sh.

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,14 @@ lazy val root = (project in file("."))
     dockerUpdateLatest := true,
     /* zmmではScala highlightのためにカスタムしたhighlight.jsを同梱しているが、mappingが今のところ壊れているのでDocker Imageでは直接highlight.jsをダウンロードさせる */
     dockerCommands ++= Seq(
+      // ExecCmd("COPY", "./entrypoint.sh", "/app/entrypoint.sh"),
+      // Cmd ("ENTRYPOINT", "[", "/app/entrypoint.sh", "]"),
+      // coretto image does not have useradd utils
       Cmd("USER", "root"),
+      ExecCmd("RUN", "yum", "install", "-y", "shadow-utils"),
+      ExecCmd("RUN", "yum", "clean", "all"),
+      ExecCmd("RUN", "useradd", "-m", "zundamon"),
+      ExecCmd("RUN", "mkdir", "/app"),
       ExecCmd("RUN", "mkdir", "-p", "/app/artifacts/html"),
       ExecCmd("RUN", "mkdir", "/app/assets"),
       ExecCmd("ADD", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js", "/app/highlight.min.js"),
@@ -76,9 +83,12 @@ lazy val root = (project in file("."))
       ExecCmd("RUN", "amazon-linux-extras", "install", "-y", "epel"),
       ExecCmd("RUN", "yum", "update", "-y"),
       ExecCmd("RUN", "yum", "install", "-y", "chromium"),
+      ExecCmd("RUN", "chown", "-R", "zundamon", "/app"),
+      Cmd("USER", "zundamon"),
       Cmd("ENV", "IS_DOCKER_ZMM=1"),
       Cmd("WORKDIR", "/app"),
     ),
+    dockerEntrypoint := Seq("./entrypoint.sh")
   )
 
 ThisBuild / assemblyMergeStrategy := {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Script to adopt uid/gid to host's.
+# See https://zenn.dev/anyakichi/articles/73765814e57cba
+
+export USER=zundamon
+export HOME=/home/zundamon
+
+uid=$(stat -c "%u" .)
+gid=$(stat -c "%g" .)
+
+if [ "$uid" -ne 0 ]; then
+    if [ "$(id -g $USER)" -ne $gid ]; then
+        # gid of $HOME should be host's
+        getent group $gid >/dev/null 2>&1 || groupmod -g $gid $USER
+        chgrp -R $gid $HOME
+    fi
+    if [ "$(id -u $USER)" -ne $uid ]; then
+        # uid of $HOME should be host's
+        usermod -u $uid $USER
+    fi
+fi
+
+# Masquerade to host's user
+exec setpriv --reuid=$USER --regid=$USER --init-groups "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@
 # Script to adopt uid/gid to host's.
 # See https://zenn.dev/anyakichi/articles/73765814e57cba
 
+# Running as root here...
+
 export USER=zundamon
 export HOME=/home/zundamon
 
@@ -21,6 +23,8 @@ if [ "$uid" -ne 0 ]; then
     fi
 fi
 
+# setpriv is a minimal tool like sudo/doas.
 # Masquerade to host's user
-# Coretto's setpriv does not have --init-groups option. we use --clear-groups
+# Coretto's setpriv does not have --init-groups option. we use --clear-groups.
+# Binaries will be deployed into /opt/docker by sbt-native-packager.
 exec setpriv --reuid=$USER --regid=$USER --clear-groups /opt/docker/bin/zmm "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,4 +22,5 @@ if [ "$uid" -ne 0 ]; then
 fi
 
 # Masquerade to host's user
-exec setpriv --reuid=$USER --regid=$USER --init-groups "$@"
+# Coretto's setpriv does not have --init-groups option. we use --clear-groups
+exec setpriv --reuid=$USER --regid=$USER --clear-groups /opt/docker/bin/zmm "$@"


### PR DESCRIPTION
cf: #30

## 前提 / Prerequisites

- ZMMはDockerで実行可能である
- ZMMはレンダリング結果や音声合成結果(アーティファクト)を`artifacts/`以下に保存する

## なぜこのPRが必要になったか / Why do we need this PR

- 保存したアーティファクトのownerがrootになってしまい、ホストから削除できなくなるという問題が発生していた
- アーティファクトのuid/gidは、ホスト環境のuid/gidと揃っていることが望ましい

## なにをやったか / What I did

- `entrypoint.sh`に細工をして、Docker image内部での実行ユーザ(zundamon)をホストのuid/gidに修正するようにした
  - ホストのuid/gidをどう得るのか？→マウントされているはずのカレントディレクトリのuid/gidから得る
  - 実行ユーザをどう切り替えるのか？→`entrypoint.sh`が起動した時点ではrootで動作し、最後に`setpriv`コマンドをexecして切り替える

## 補足 / Supplementary information

実行環境として想定しているcorettoのsetprivには`--init-groups`が無かった(おそらくバージョンの問題)。しょうがないので`--clear-groups`で代替している。実行イメージをcoretto以外のものにしてもよいが、今のところcorettoが安定しているので妥協した。