### PR TITLE
forkしたrepoからのpull reqでscalafmt失敗する問題修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: ${{ github.repository_owner == 'windymelt' }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- 

## なぜこのPRが必要になったか / Why do we need this PR

- forkしたrepoからのpull reqだと原理上checkoutに失敗してるので
- https://github.com/windymelt/zmm/pull/35#issuecomment-1912948467


## なにをやったか / What I did

- forkされた場合のrepoの場合は一旦暫定的にskip

## 補足 / Supplementary information

- 別途、(おそらくやってないので？)scalafmtAllCheckやscalafmtSbtCheckを入れるべきだと思うが、一旦入れてない
- そもそも、forkしてない場合においても、デフォルトのtokenでpushするとCIが動かないので、この方法自体が(少なくとも独自token設定するか何かでもっと工夫しないと) 色々微妙だと思う