### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ lazy val root = (project in file("."))
     name := "zmm",
     publish / skip := true,
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
       "org.typelevel" %% "cats-effect" % "3.3.12",
       "org.http4s" %% "http4s-ember-client" % "0.23.16",
       "org.http4s" %% "http4s-circe" % "0.23.16",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.1")
+addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.0.3")
 // for providing version into code
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
@@ -6,6 +6,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.4")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- 

## なぜこのPRが必要になったか / Why do we need this PR

- 依存ライブラリ上げていきたい

## なにをやったか / What I did

- 中途半端に少しだけ上げても、衝突を無視する設定を入れない限り、xmlやparser-combinatorが衝突してbuild不可能になるので、関連するもの全部あげた
- 明示的なxmlの依存は(少なくとも)古いままだとエラーなので、最新を明記してもいいが、別に明記しなくても(間接的な依存のやつで)動くので、一旦消した

## 補足 / Supplementary information

- 他にもいっぱいあるがscala-stewardに任せる
- ただし、これ https://github.com/windymelt/zmm/pull/66 のせいでscala-steward含めた大半のpull reqのCIが、おそらく通らないが