### PR TITLE
forkからpull reqした場合scalafmt失敗するのでskip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: ${{ github.repository_owner == 'windymelt' }}
+    if: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'windymelt' }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- 

## なぜこのPRが必要になったか / Why do we need this PR

- これダメだった https://github.com/windymelt/zmm/pull/66

## なにをやったか / What I did

- 別の方法で判断
- 本当は `github.event.pull_request.user.login` よりもっといい方法ある気がするけど暫定的に

## 補足 / Supplementary information