### PR TITLE
objectにfinalが付与されているのを削除

### DIFF
--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/ChromeScreenShot.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/ChromeScreenShot.scala
@@ -10,8 +10,8 @@ trait ChromeScreenShotComponent {
 
   object ChromeScreenShot {
     sealed trait Verbosity
-    final object Quiet extends Verbosity
-    final object Verbose extends Verbosity
+    object Quiet extends Verbosity
+    object Verbose extends Verbosity
   }
 
   def screenShotResource: IO[Resource[IO, ScreenShot]]

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/FFmpeg.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/FFmpeg.scala
@@ -11,8 +11,8 @@ trait FFmpegComponent {
 
   object ConcreteFFmpeg {
     sealed trait Verbosity
-    final object Quiet extends Verbosity
-    final object Verbose extends Verbosity
+    object Quiet extends Verbosity
+    object Verbose extends Verbosity
   }
 
   def ffmpeg: ConcreteFFmpeg

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/FirefoxScreenShotComponent.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/FirefoxScreenShotComponent.scala
@@ -13,8 +13,8 @@ trait FirefoxScreenShotComponent {
 
   object FirefoxScreenShot {
     sealed trait Verbosity
-    final object Quiet extends Verbosity
-    final object Verbose extends Verbosity
+    object Quiet extends Verbosity
+    object Verbose extends Verbosity
   }
 
   def screenShotResource: IO[Resource[IO, ScreenShot]]


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- 

## なぜこのPRが必要になったか / Why do we need this PR

- Scala 3で警告が出るため
- (すごく大昔のScalaでは意味がある場合があったが)今のScalaではobjectはfinalであって、つける意味が実質ないため

## なにをやったか / What I did

- final消した

## 補足 / Supplementary information