### PR TITLE
implicitな `Monoid[Context]` の明示的な型を明記

### DIFF
--- a/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
+++ b/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala
@@ -61,7 +61,7 @@ object Context {
   import scala.xml.{Text, Node, Elem, Comment}
 
   // Context is a Monoid
-  implicit val monoidForContext = new Monoid[Context] {
+  implicit val monoidForContext: Monoid[Context] = new Monoid[Context] {
     def combine(x: Context, y: Context): Context = {
       val spokenByCharacterId = y.spokenByCharacterId |+| x.spokenByCharacterId
       val characterConfigMap = x.characterConfigMap ++ y.characterConfigMap


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- 

## なぜこのPRが必要になったか / Why do we need this PR

- Scala 2.13.12だと警告
- Scala 3だとエラー

```
[warn] /home/runner/work/zmm/zmm/src/main/scala/com/github/windymelt/zmm/domain/model/Context.scala:64:16: Implicit definition should have explicit type (inferred cats.Monoid[com.github.windymelt.zmm.domain.model.Context]) [quickfixable]
[warn]   implicit val monoidForContext = new Monoid[Context] {
[warn]                ^
```

## なにをやったか / What I did

- 型書いた

## 補足 / Supplementary information