### PR TITLE
no auto format in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,19 @@ on:
       - main
 
 jobs:
-  format:
+  checkFmt:
+    name: Scalafmt check
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    if: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'windymelt' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
           cache: 'sbt'
       - uses: coursier/cache-action@v6
-      - name: sbt scalafmtAll
-        run: sbt scalafmtAll scalafmtSbt
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Apply scalafmt
+      - name: sbt scalafmtCheckAll
+        run: sbt scalafmtCheckAll
   build-test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- CIでscalafmtを自動的にかけるようにしていた

## なぜこのPRが必要になったか / Why do we need this PR

- botなどはpermissionなどの問題で実行できない。
- このためCIがコケたりして実質的に意味がない

## なにをやったか / What I did

- CIでscalafmtかけるのをやめる
- かわりに`scalafmtCheckAll`させて失敗したらコケさせる
- scalafmtは手元でやればよい

## 補足 / Supplementary information