### PR TITLE
フリーフォント(Rounded M+)を同梱する + フォントディレクトリ修正 ほか

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val root = (project in file("."))
       // Initnally, run as root. Go to protected user inside entrypoint.sh.
       Cmd("USER", "root"),
       // coretto image does not have useradd utils
-      ExecCmd("RUN", "yum", "install", "-y", "shadow-utils"),
+      ExecCmd("RUN", "yum", "install", "-y", "shadow-utils", "unzip"),
       ExecCmd("RUN", "yum", "clean", "all"),
       // Add protected user. entrypoint.sh uses this.
       ExecCmd("RUN", "useradd", "-m", "zundamon"),
@@ -79,6 +79,23 @@ lazy val root = (project in file("."))
       ExecCmd("RUN", "mkdir", "-p", "/app/artifacts/html"),
       ExecCmd("RUN", "mkdir", "/app/assets"),
       // Install dependencies
+      // font
+      ExecCmd(
+        "ADD",
+        "https://ftp.iij.ad.jp/pub/osdn.jp/users/8/8574/rounded-mplus-20150529.zip",
+        "/tmp/mplus.zip"
+      ),
+      ExecCmd(
+        "RUN",
+        "unzip",
+        "-d",
+        "/usr/share/fonts",
+        "/tmp/mplus.zip"
+      ),
+      ExecCmd(
+        "RUN",
+        "fc-cache"
+      ),
       ExecCmd(
         "ADD",
         "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js",
@@ -98,11 +115,12 @@ lazy val root = (project in file("."))
         "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
       ),
       ExecCmd("RUN", "tar", "xvf", "ffmpeg-release-amd64-static.tar.xz"),
-      ExecCmd("RUN", "mv", "ffmpeg-6.0-amd64-static/ffmpeg", "/usr/bin/ffmpeg"),
+      // output directory sometimes changes according to latest version.
+      ExecCmd("RUN", "mv", "ffmpeg-6.1-amd64-static/ffmpeg", "/usr/bin/ffmpeg"),
       ExecCmd(
         "RUN",
         "mv",
-        "ffmpeg-6.0-amd64-static/ffprobe",
+        "ffmpeg-6.1-amd64-static/ffprobe",
         "/usr/bin/ffprobe"
       ),
       ExecCmd("RUN", "amazon-linux-extras", "install", "-y", "epel"),

--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,11 @@ lazy val root = (project in file("."))
       ),
       ExecCmd(
         "RUN",
+        "rm",
+        "/tmp/mplus.zip"
+      ),
+      ExecCmd(
+        "RUN",
         "fc-cache"
       ),
       ExecCmd(
@@ -122,6 +127,13 @@ lazy val root = (project in file("."))
         "mv",
         "ffmpeg-6.1-amd64-static/ffprobe",
         "/usr/bin/ffprobe"
+      ),
+      ExecCmd(
+        "RUN",
+        "rm",
+        "-rf",
+        "ffmpeg-release-amd64-static.tar.xz",
+        "ffmpeg-6.1-amd64-static/"
       ),
       ExecCmd("RUN", "amazon-linux-extras", "install", "-y", "epel"),
       ExecCmd("RUN", "yum", "update", "-y"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - "./:/app"
       # 手元にあるフォントを使えるようにする措置
-      - "$HOME/.fonts/:/root/.fonts:ro"
+      - "$HOME/.fonts/:/usr/share/fonts/zmm/:ro"
     working_dir: /app
     environment:
       - "VOICEVOX_URI=http://voicevox-cpu:50021"

--- a/sample.xml
+++ b/sample.xml
@@ -20,7 +20,7 @@
     <dict pronounce="ゼットエムエ_ム">zmm</dict>
     <dict pronounce="モチー_フ">motif</dict>
     <dict pronounce="コー_ド">code</dict>
-    <font>Corporate Logo ver3</font>
+    <font>'Rounded M+ 1c'</font>
   </meta>
   <predef>
     <code id="code1" lang="scala">


### PR DESCRIPTION
solves: #85

## 前提 / Prerequisites

- ZMMにはフォントが同梱されていない

## なぜこのPRが必要になったか / Why do we need this PR

- フォントがうまくレンダされず豆腐になっているという報告が寄せられた
- フリーフォントでありライセンス上問題なければDockerイメージに同梱していいはず
- フォントディレクトリの指定もうまくいっていない様子だった

## なにをやったか / What I did

- Rounded M+をDockerイメージの生成過程で同梱した (ライセンス http://jikasei.me/font/rounded-mplus/license.html)
- フォント指定のディレクトリを`/root/.fonts`から`/usr/share/fonts/zmm`に変更した
- ffmpegのバージョンが更新されてDockerイメージビルドがコケていたので追従

## 補足 / Supplementary information

デフォルトでは`unzip`が入っていないのでイメージに同梱した。