### PR TITLE
add merge strategy for module-info.class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,6 +150,8 @@ lazy val root = (project in file("."))
 ThisBuild / assemblyMergeStrategy := {
   case PathList("META-INF", "versions", "9", "module-info.class") =>
     MergeStrategy.first
+  case PathList("module-info.class") =>
+    MergeStrategy.first
   case x =>
     val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
     oldStrategy(x)


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- logbackには`module-info.class`というファイルが入っているが、Scalaには関係がないので無視したい

## なぜこのPRが必要になったか / Why do we need this PR

- 複数のライブラリが`module-info.class`を持っており、uberjarを作るときにconflictする

## なにをやったか / What I did

- merge strategyを追加してfirstにした

## 補足 / Supplementary information