### PR TITLE
Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.packager.docker._
 
 import ReleaseTransformations._
 
-ThisBuild / scalaVersion := "2.13.12"
+ThisBuild / scalaVersion := "3.3.0"
 ThisBuild / organization := "com.github.windymelt"
 ThisBuild / organizationName := "windymelt"
 

--- a/src/main/scala/com/github/windymelt/zmm/domain/model/Filter.scala
+++ b/src/main/scala/com/github/windymelt/zmm/domain/model/Filter.scala
@@ -4,7 +4,7 @@ import cats.data.Kleisli
 import cats.implicits._
 
 object Filter {
-  def talkingMouthFilter: Filter[Seq] = Kleisli { ctx: Context =>
+  def talkingMouthFilter: Filter[Seq] = Kleisli { (ctx: Context) =>
     ctx.spokenVowels match {
       case None => Seq(ctx)
       case Some(vs) =>


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- @xuwei-k さんのパワーでScala 3で普通にコンパイルできる状態に近付いていた

## なぜこのPRが必要になったか / Why do we need this PR

- ZMMはライブラリではなくアプリケーションなので、Scala 3にいきなり移行してもさほど問題ない

## なにをやったか / What I did

- `Filter`のちょっとした記法を修正
- とりあえずLTSになっているScala 3.3.0を導入

## 補足 / Supplementary information