### PR TITLE
アセット向けのエイリアス記法を導入

### DIFF
--- a/sample.xml
+++ b/sample.xml
@@ -13,10 +13,10 @@
     <voiceconfig id="tsumugi" backend="voicevox">
       <voicevoxconfig id="8" />
     </voiceconfig>
-    <characterconfig name="char1" voice-id="metan" serif-color="#E14D2A" tachie-url="../../assets/metan.png" />
-    <characterconfig name="char2" voice-id="zundamon" serif-color="#379237" tachie-url="../../assets/zunda.png" />
-    <characterconfig name="char2_hiso" voice-id="zundamon-hisohiso" tachie-url="../../assets/zunda.png" />
-    <characterconfig name="char3" voice-id="tsumugi" tachie-url="../../assets/tsumugi.png" />
+    <characterconfig name="char1" voice-id="metan" serif-color="#E14D2A" tachie-url="@assets/metan.png" />
+    <characterconfig name="char2" voice-id="zundamon" serif-color="#379237" tachie-url="@assets/zunda.png" />
+    <characterconfig name="char2_hiso" voice-id="zundamon-hisohiso" tachie-url="@assets/zunda.png" />
+    <characterconfig name="char3" voice-id="tsumugi" tachie-url="@assets/tsumugi.png" />
     <dict pronounce="ゼットエムエ_ム">zmm</dict>
     <dict pronounce="モチー_フ">motif</dict>
     <dict pronounce="コー_ド">code</dict>
@@ -41,7 +41,7 @@ def groupReduction[E : Eq, S : Semigroup](xs: Seq[(E, S)]): Seq[(E, S)] = {
     ]]>
     </code>
   </predef>
-  <dialogue backgroundImage="" bgm="assets/nc282335_20%.mp3">
+  <dialogue backgroundImage="" bgm="">
   <!-- TODO: assetのパスをhtmlからのパスではなくxmlからのパスにする、asset: schemeの導入 -->
     <say by="char1" motif="ここには解説を表示できます">このXMLファイルは、zmmの動作を説明するためのサンプルです。</say>
     <say by="char1">キャラクター1の音声です。</say>

--- a/src/main/scala/com/github/windymelt/zmm/Cli.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Cli.scala
@@ -165,7 +165,11 @@ abstract class Cli(logLevel: String = "INFO")
         // たとえば、BGMa 5sec BGMa 5sec BGMb 10sec であるときは、 BGMa 10sec BGMb 10secに簡約される。
         val bgmWithDuration: Seq[(Option[os.Path], FiniteDuration)] =
           sayCtxPairs
-            .map(p => p._2.bgm.map(os.pwd / os.RelPath(_)) -> p._2.duration.get)
+            .map(p =>
+              p._2.bgm.map(path =>
+                os.pwd / os.RelPath(util.PathAlias.resolve(path, "ffmpeg"))
+              ) -> p._2.duration.get
+            )
 
         val reductedBgmWithDuration = groupReduction(bgmWithDuration)
 

--- a/src/main/scala/com/github/windymelt/zmm/util/PathAlias.scala
+++ b/src/main/scala/com/github/windymelt/zmm/util/PathAlias.scala
@@ -1,0 +1,20 @@
+package com.github.windymelt.zmm.util
+
+/** {{{@assets/}}}
+  * などのエイリアス記法を変換する機構。これによりHTMLレンダリングやffmpegのBGM合成などの文脈からXMLファイルのパス記述を切り離し、処理プロセスがユーザから隠蔽される。
+  */
+object PathAlias {
+  type Purpose = "template" | "ffmpeg"
+  def resolve(aliasPath: String, purpose: Purpose): String = aliasPath match {
+    case AliasRe(annotation, rest) =>
+      annotationPathMap(annotation)(purpose) ++ rest
+    case _ => aliasPath
+  }
+  private val AliasRe = """@([^/]+)/(.+)""".r.anchored
+  private val annotationPathMap: Map[String, Map[Purpose, String]] = Map(
+    "assets" -> Map(
+      "template" -> "../../assets/",
+      "ffmpeg" -> "./assets/"
+    )
+  )
+}

--- a/src/main/twirl/sample.scala.html
+++ b/src/main/twirl/sample.scala.html
@@ -1,7 +1,7 @@
 @(serif: String, ctx: com.github.windymelt.zmm.domain.model.Context)
 @font() = {@ctx.font.getOrElse("sans-serif")}
 <html><!-- TODO: embed SHA-256 of background image. -->
-    <body style="@ctx.backgroundImageUrl.map(url => s"background-image: url('${url}');" ).getOrElse("") background-size: 100%;">
+    <body style="@ctx.backgroundImageUrl.map(url => s"background-image: url('${com.github.windymelt.zmm.util.PathAlias.resolve(url, "template")}');" ).getOrElse("") background-size: 100%;">
     <!-- Highlight.js -->
     <link rel="stylesheet"
           href="../../default.min.css">
@@ -37,7 +37,7 @@
             }
             </pre>
         </div>
-        <img alt="" src="@ctx.tachieUrl.getOrElse("")" onerror='this.style.display = "none"' style="position: fixed; height: 100%; bottom: -30%; right: -5%;" />
+        <img alt="" src="@com.github.windymelt.zmm.util.PathAlias.resolve(ctx.tachieUrl.getOrElse(""), "template")" onerror='this.style.display = "none"' style="position: fixed; height: 100%; bottom: -30%; right: -5%;" />
         <div style="background-color: rgba(0,0,0,0.5); position: fixed; left: 0px; bottom: 0px; height: 25%; width: 100%; font-size: 48pt; padding: 1em 0 0 0;">
             <div style="padding:0 1em 0 1em; font-family: @font(); font-weight: 800; color: white; -webkit-text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")}; text-stroke: 0.05em @{ctx.serifColor.getOrElse("black")}; filter: drop-shadow(0 0 0.3em #ccc); text-align: center;"><budoux-ja>@serif</budoux-ja></div>
             <!-- <div style="padding:0 1em 0 1em; font-family: Corporate Logo ver3; font-weight: 800; color: white; -webkit-text-stroke: 0.05em black; text-stroke: 0.05em black;">

--- a/src/main/twirl/script.scala.xml
+++ b/src/main/twirl/script.scala.xml
@@ -8,14 +8,14 @@
       <voicevoxconfig id="3" />
     </voiceconfig>
     <characterconfig name="metan" voice-id="metan" serif-color="#E14D2A"
-                     tachie-url="../../assets/めたんの立ち絵を設定してください" />
+                     tachie-url="@@assets/めたんの立ち絵を設定してください" />
     <characterconfig name="zunda" voice-id="zundamon" serif-color="#379237"
-                     tachie-url="../../assets/ずんだもんの立ち絵を設定してください" />
+                     tachie-url="@@assets/ずんだもんの立ち絵を設定してください" />
     <dict pronounce="ゼットエムエ_ム">zmm</dict>
   </meta>
   <predef>
   </predef>
-  <dialogue backgroundImage="../../assets/ここに背景画像を設定してください" bgm="assets/ここにBGMファイルを設定してください">
+  <dialogue backgroundImage="@@assets/ここに背景画像を設定してください" bgm="@@assets/ここにBGMファイルを設定してください">
   <scene>
   <say by="metan">こんにちは、四国めたんです</say>
   <say by="zunda">こんにちは、ずんだもんなのだ</say>

--- a/src/test/scala/com/github/windymelt/zmm/util/PathAliasSpec.scala
+++ b/src/test/scala/com/github/windymelt/zmm/util/PathAliasSpec.scala
@@ -1,0 +1,21 @@
+package com.github.windymelt.zmm.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PathAliasSpec extends AnyFlatSpec with Matchers {
+
+  "PathAlias" should "resolve @assets" in {
+    PathAlias.resolve("./do/not/modify", "template") shouldBe "./do/not/modify"
+
+    PathAlias.resolve(
+      "@assets/foo/bar.png",
+      "template"
+    ) shouldBe "../../assets/foo/bar.png"
+
+    PathAlias.resolve(
+      "@assets/foo/bar.mp3",
+      "ffmpeg"
+    ) shouldBe "./assets/foo/bar.mp3"
+  }
+}


### PR DESCRIPTION
solves: #

## 前提 / Prerequisites

- ZMMはブラウザによるレンダリングやffmpegによる合成を利用しているため、文脈によってカレントディレクトリが異なる
  - ブラウザからはテンプレートHTMLから見たパスを用いて画像ファイルのパスを指定しなければならない

## なぜこのPRが必要になったか / Why do we need this PR

- XMLファイルにこのパスの問題が露出しており、使いづらい状態になっていた
- ユーザがこの差異を知る必要は全くない

## なにをやったか / What I did

- `@assets/foo.png`といった記法を導入した(`tsconfig`などで見るおなじみの記法)
  - この記法は自動的にブラウザやffmpegの文脈によって読み替えられ、適切なパスに変換されるためエンドユーザはこの記法で書けばよい
- サンプルXMLファイル、テンプレートXMLファイルの追従
- テスト

## 補足 / Supplementary information