### PR TITLE
reduce timeout to 5 min

### DIFF
--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/VoiceVox.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/VoiceVox.scala
@@ -180,7 +180,7 @@ trait VoiceVoxComponent {
       import scala.language.postfixOps
       EmberClientBuilder
         .default[IO]
-        .withTimeout(10 minutes)
+        .withTimeout(5 minutes)
         .withIdleConnectionTime(10 minutes)
         .build
     }


### PR DESCRIPTION
solves: https://github.com/windymelt/zmm/issues/94

## 前提 / Prerequisites

- タイムアウトの警告出る

## なぜこのPRが必要になったか / Why do we need this PR

- http4sを更新したところ警告が出るようになった

## なにをやったか / What I did

- timeoutを短くする(これで問題ない)

## 補足 / Supplementary information