### PR TITLE
Dockerfile-ffmpeg を利用する ffmpeg バックエンドを追加する

### DIFF
--- a/Dockerfile-ffmpeg
+++ b/Dockerfile-ffmpeg
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
+FROM node:24.13.0-bookworm
+ENV FFMPEG_VERSION=6.1
+
+RUN apt update -y
+ADD https://johnvansickle.com/ffmpeg/releases/ffmpeg-${FFMPEG_VERSION}-amd64-static.tar.xz ffmpeg.tar.xz
+RUN tar xvf ffmpeg.tar.xz
+RUN mv ffmpeg-${FFMPEG_VERSION}-amd64-static/ffmpeg /usr/local/bin/ffmpeg
+RUN mv ffmpeg-${FFMPEG_VERSION}-amd64-static/ffprobe /usr/local/bin/ffprobe

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,8 @@ lazy val root = (project in file("."))
       scalaTest % Test,
     ),
     assembly / mainClass := Some("com.github.windymelt.zmm.Main"),
+    // DockerFFmpeg がイメージビルドに利用するため、Dockerfile-ffmpeg を jar に同梱する
+    Compile / unmanagedResources += baseDirectory.value / "Dockerfile-ffmpeg",
   )
   .enablePlugins(SbtTwirl)
   .enablePlugins(BuildInfoPlugin)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -13,4 +13,5 @@ firefox {
 
 ffmpeg {
   command = "ffmpeg"
+  dockerImage = "zmm-ffmpeg:latest"
 }

--- a/src/main/scala/com/github/windymelt/zmm/CliOptions.scala
+++ b/src/main/scala/com/github/windymelt/zmm/CliOptions.scala
@@ -28,6 +28,7 @@ final case class Generate(
     targetFile: TargetFile,
     outputFile: java.nio.file.Path,
     screenShotBackend: Option[ScreenShotBackend],
+    ffmpegBackend: Option[FFmpegBackend],
     verbosity: Option[Int],
 ) extends ZmmOption
 
@@ -45,6 +46,12 @@ sealed trait ScreenShotBackend
 object ScreenShotBackend {
   final case object Chrome extends ScreenShotBackend
   final case object Firefox extends ScreenShotBackend
+}
+
+sealed trait FFmpegBackend
+object FFmpegBackend {
+  case object Local extends FFmpegBackend
+  case object Docker extends FFmpegBackend
 }
 
 object CliOptions {
@@ -87,6 +94,23 @@ object CliOptions {
     }
     .orNone
 
+  private val ffmpegBackend = Opts
+    .option[String](
+      "ffmpeg",
+      help = "Backend for ffmpeg. local or docker.",
+      metavar = "local | docker",
+    )
+    .mapValidated {
+      case "local"  => Validated.valid(FFmpegBackend.Local)
+      case "docker" => Validated.valid(FFmpegBackend.Docker)
+      case _ =>
+        Validated.invalid(
+          "ffmpeg backend should be one of local and docker"
+            .pure[NonEmptyList],
+        )
+    }
+    .orNone
+
   private val verbosityFlag = Opts
     .flags(
       "verbose",
@@ -99,6 +123,7 @@ object CliOptions {
       targetFile,
       outputFile,
       screenShotBackend,
+      ffmpegBackend,
       verbosityFlag,
     ) mapN (Generate.apply)
 

--- a/src/main/scala/com/github/windymelt/zmm/Design.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Design.scala
@@ -3,14 +3,21 @@ package com.github.windymelt.zmm
 import com.typesafe.config.Config
 import sttp.client4.httpclient.zio.HttpClientZioBackend
 import zio.Semaphore
+import zio.Task
 import zio.ZIO
 import zio.ZLayer
-import infrastructure.{ChromeScreenShot, ConcreteFFmpeg, FirefoxScreenShot}
+import infrastructure.{
+  ChromeScreenShot,
+  ConcreteFFmpeg,
+  DockerFFmpeg,
+  FirefoxScreenShot,
+}
 
 object Design:
   def chrome(
       config: Config,
       logLevel: String = "INFO",
+      ffmpegBackend: FFmpegBackend = FFmpegBackend.Local,
   ): ZLayer[Any, Throwable, Cli] = {
     val chromiumCommand =
       sys.env
@@ -21,7 +28,7 @@ object Design:
       .map(_ == "1")
       .getOrElse(config.getBoolean("chromium.nosandbox"))
 
-    cliLayer(config, logLevel) { () =>
+    cliLayer(config, logLevel, ffmpegBackend) { () =>
       new ChromeScreenShot(
         chromiumCommand,
         logLevel match {
@@ -41,11 +48,12 @@ object Design:
   def firefox(
       config: Config,
       logLevel: String = "INFO",
+      ffmpegBackend: FFmpegBackend = FFmpegBackend.Local,
   ): ZLayer[Any, Throwable, Cli] = {
     val firefoxCommand =
       sys.env.get("FIREFOX_CMD").getOrElse(config.getString("firefox.command"))
 
-    cliLayer(config, logLevel) { () =>
+    cliLayer(config, logLevel, ffmpegBackend) { () =>
       new FirefoxScreenShot(
         firefoxCommand,
         logLevel match {
@@ -58,7 +66,11 @@ object Design:
 
   }
 
-  private def cliLayer(config: Config, logLevel: String)(
+  private def cliLayer(
+      config: Config,
+      logLevel: String,
+      ffmpegBackend: FFmpegBackend,
+  )(
       makeScreenShot: () => domain.repository.ScreenShot,
   )(logSetting: zio.UIO[Unit]): ZLayer[Any, Throwable, Cli] = {
     val ffmpegVerbosity = logLevel match
@@ -69,15 +81,32 @@ object Design:
     val voiceVoxUri =
       sys.env.getOrElse("VOICEVOX_URI", config.getString("voicevox.apiUri"))
 
+    // ffmpegバックエンドの組み立て。Dockerの場合はLayer構築時にイメージをビルドする
+    val makeFFmpeg: Task[domain.repository.FFmpeg] = ffmpegBackend match
+      case FFmpegBackend.Local =>
+        ZIO.succeed(
+          ConcreteFFmpeg(config.getString("ffmpeg.command"), ffmpegVerbosity),
+        )
+      case FFmpegBackend.Docker =>
+        val imageTag = sys.env.getOrElse(
+          "FFMPEG_DOCKER_IMAGE",
+          config.getString("ffmpeg.dockerImage"),
+        )
+        ZIO.logInfo(s"Building ffmpeg docker image: $imageTag") *>
+          DockerFFmpeg
+            .buildImage(imageTag, ffmpegVerbosity)
+            .as(DockerFFmpeg(imageTag, ffmpegVerbosity))
+
     ZLayer.scoped {
       for {
         _ <- logSetting
         backend <- HttpClientZioBackend.scoped()
+        ffmpeg <- makeFFmpeg
         // スクリーンショットバックエンドは同時起動できないためSemaphore(1)で直列化する
         sem <- Semaphore.make(1)
       } yield new Cli(
         voiceVox = infrastructure.ConcreteVoiceVox(voiceVoxUri, backend),
-        ffmpeg = ConcreteFFmpeg("ffmpeg", ffmpegVerbosity),
+        ffmpeg = ffmpeg,
         screenShot = ScreenShotService(sem, makeScreenShot),
       )
     }

--- a/src/main/scala/com/github/windymelt/zmm/Main.scala
+++ b/src/main/scala/com/github/windymelt/zmm/Main.scala
@@ -58,7 +58,7 @@ object Main extends ZIOAppDefault {
               "subcommand [show] only accepts 'voicevox'. try `show voicevox`",
             ) *> ZIO.succeed(ExitCode.failure)
         }
-      case Generate(file, out, screenShotBackend, verbosity) =>
+      case Generate(file, out, screenShotBackend, ffmpegBackend, verbosity) =>
         val optionalLogLevel = verbosityToLogLevel(
           vCount = verbosity.getOrElse(0),
           qCount = 0, /* TODO: implement it later */
@@ -67,12 +67,13 @@ object Main extends ZIOAppDefault {
         val logLevel = environmentalLogLevel.getOrElse(optionalLogLevel)
         setLogLevel(logLevel)
 
+        val ffmpeg = ffmpegBackend.getOrElse(FFmpegBackend.Local)
         val cliLayer = screenShotBackend match
           // TODO: ffmpeg verbosityをcli opsから設定可能にする
           case Some(ScreenShotBackend.Firefox) =>
-            Design.firefox(util.Util.config, logLevel)
+            Design.firefox(util.Util.config, logLevel, ffmpeg)
           case _ =>
-            Design.chrome(util.Util.config, logLevel)
+            Design.chrome(util.Util.config, logLevel, ffmpeg)
 
         ZIO
           .serviceWithZIO[Cli] { cli =>

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/DockerFFmpeg.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/DockerFFmpeg.scala
@@ -1,0 +1,75 @@
+package com.github.windymelt.zmm
+package infrastructure
+
+import zio.Task
+import zio.ZIO
+
+object DockerFFmpeg {
+
+  /** jar に同梱した Dockerfile-ffmpeg から ffmpeg 実行用の Docker イメージをビルドする。
+    *
+    * Dockerfile は ADD で静的ビルドの ffmpeg を取得するだけでビルドコンテキストを必要としないため、
+    * 標準入力経由でビルドする。2回目以降は Docker のレイヤーキャッシュが効くため高速に完了する。
+    *
+    * @param imageTag
+    *   ビルドするイメージのタグ
+    * @param verbosity
+    *   ビルドログの出力有無
+    */
+  def buildImage(
+      imageTag: String,
+      verbosity: ConcreteFFmpeg.Verbosity,
+  ): Task[Unit] = ZIO.attemptBlocking {
+    val dockerfile = scala.io.Source
+      .fromInputStream(
+        getClass().getClassLoader().getResourceAsStream("Dockerfile-ffmpeg"),
+      )
+      .mkString
+    val out = verbosity match {
+      case ConcreteFFmpeg.Quiet   => os.Pipe
+      case ConcreteFFmpeg.Verbose => os.Inherit
+    }
+    os.proc("docker", "build", "-t", imageTag, "-")
+      .call(stdin = dockerfile, stdout = out, stderr = out, cwd = os.pwd)
+  }.unit
+}
+
+/** Dockerfile-ffmpeg からビルドしたイメージ上で ffmpeg / ffprobe を実行する実装。
+  *
+  * ホストに ffmpeg をインストールしなくても動画生成できるようにするための実装。 カレントディレクトリをコンテナ内の同一パスにマウントすることで、
+  * cutfile 等に記述された絶対パスをコンテナ内でもそのまま解決できるようにしている。
+  */
+class DockerFFmpeg(
+    imageTag: String,
+    verbosity: ConcreteFFmpeg.Verbosity,
+) extends ConcreteFFmpeg("ffmpeg", verbosity) {
+  // コンテナがrootでファイルを書くとホスト側から上書きできなくなるため、ホストと同じUID/GIDで実行する
+  private lazy val hostUidGid: String = {
+    val uid = os.proc("id", "-u").call().out.text().trim
+    val gid = os.proc("id", "-g").call().out.text().trim
+    s"$uid:$gid"
+  }
+
+  private def dockerRunPrefix: Seq[os.Shellable] = Seq[os.Shellable](
+    "docker",
+    "run",
+    "--rm",
+    "-i", // concatenateWavFiles が標準入力を渡すため必要
+    "--user",
+    hostUidGid,
+    // SELinux 環境でマウントしたファイルへのアクセスが拒否されないようにする。
+    // :z と異なりホスト側ファイルのラベルを書き換えない。SELinux 無効の環境では単に無視される
+    "--security-opt",
+    "label=disable",
+    "-v",
+    s"${os.pwd}:${os.pwd}",
+    "-w",
+    s"${os.pwd}",
+    imageTag,
+  )
+
+  override protected def ffmpegBaseCommand: Seq[os.Shellable] =
+    dockerRunPrefix :+ ("ffmpeg": os.Shellable)
+  override protected def ffprobeBaseCommand: Seq[os.Shellable] =
+    dockerRunPrefix :+ ("ffprobe": os.Shellable)
+}

--- a/src/main/scala/com/github/windymelt/zmm/infrastructure/FFmpeg.scala
+++ b/src/main/scala/com/github/windymelt/zmm/infrastructure/FFmpeg.scala
@@ -22,6 +22,14 @@ class ConcreteFFmpeg(
     case ConcreteFFmpeg.Quiet   => os.Pipe
     case ConcreteFFmpeg.Verbose => os.Inherit
   }
+
+  // コマンドの組み立てをサブクラスで差し替えられるようにしておく(cf. DockerFFmpeg)
+  protected def ffmpegBaseCommand: Seq[os.Shellable] = Seq(ffmpegCommand)
+  protected def ffprobeBaseCommand: Seq[os.Shellable] = Seq("ffprobe")
+  protected def ffmpegProc(args: os.Shellable*): os.proc =
+    os.proc((ffmpegBaseCommand ++ args)*)
+  protected def ffprobeProc(args: os.Shellable*): os.proc =
+    os.proc((ffprobeBaseCommand ++ args)*)
   def concatenateWavFiles(files: Seq[File]): Task[os.Path] = {
     // stub
     val fileList = files.map(f => s"file '${f}'").mkString("\n")
@@ -31,24 +39,22 @@ class ConcreteFFmpeg(
       os.write(fileListPath, fileList)
     } *>
       ZIO.attemptBlocking {
-        os
-          .proc(
-            ffmpegCommand,
-            "-protocol_whitelist",
-            "file",
-            "-y", // overwrite if exists
-            "-f",
-            "concat",
-            "-safe", // go despite of not being absolute path
-            "0",
-            "-i",
-            "fileList.txt",
-            "-c",
-            "copy",
-            "-ac", // ステレオ化する
-            "2",
-            "artifacts/concatenated.wav",
-          )
+        ffmpegProc(
+          "-protocol_whitelist",
+          "file",
+          "-y", // overwrite if exists
+          "-f",
+          "concat",
+          "-safe", // go despite of not being absolute path
+          "0",
+          "-i",
+          "fileList.txt",
+          "-c",
+          "copy",
+          "-ac", // ステレオ化する
+          "2",
+          "artifacts/concatenated.wav",
+        )
           .call(
             stdout = stdout,
             stderr = stdout,
@@ -65,8 +71,7 @@ class ConcreteFFmpeg(
     import concurrent.duration.FiniteDuration
 
     ZIO.attemptBlocking {
-      val commandResult = os
-        .proc("ffprobe", os.Path(file, os.pwd))
+      val commandResult = ffprobeProc(os.Path(file, os.pwd))
         .call(cwd = os.pwd, stderr = os.Pipe, stdout = stdout)
       val durationRegex =
         """Duration: (\d\d):(\d\d):(\d\d)\.(\d\d)""".r.unanchored
@@ -112,8 +117,7 @@ class ConcreteFFmpeg(
       _ <- writeCutfile
       _ <- ZIO.attemptBlocking {
         // TODO: move to infra layer
-        os.proc(
-          ffmpegCommand,
+        ffmpegProc(
           "-protocol_whitelist",
           "file",
           "-y",
@@ -160,8 +164,7 @@ class ConcreteFFmpeg(
     for {
       _ <- writeCutfile
       bgm <- ZIO.attemptBlocking {
-        os.proc(
-          ffmpegCommand,
+        ffmpegProc(
           "-protocol_whitelist",
           "file",
           "-y",
@@ -176,8 +179,7 @@ class ConcreteFFmpeg(
         os.pwd / os.RelPath("artifacts/concatenatedBGM.wav")
       }
       _ <- ZIO.attemptBlocking {
-        os.proc(
-          ffmpegCommand,
+        ffmpegProc(
           "-y",
           "-i",
           videoPath,
@@ -226,8 +228,7 @@ class ConcreteFFmpeg(
       if (paddingDur.isEmpty) ZIO.none
       else
         ZIO.attemptBlocking {
-          os.proc(
-            ffmpegCommand,
+          ffmpegProc(
             "-protocol_whitelist",
             "file",
             "-y",
@@ -284,8 +285,7 @@ class ConcreteFFmpeg(
     // 背景動画を結合するための処理。
     val combineBaseVideo: Path => Task[Path] = (cutFilePath: os.Path) =>
       ZIO.attemptBlocking {
-        os.proc(
-          ffmpegCommand,
+        ffmpegProc(
           "-protocol_whitelist",
           "file",
           "-y",
@@ -306,8 +306,7 @@ class ConcreteFFmpeg(
     // 入力されるMKVファイルは第2ストリームにアルファチャンネル情報を格納してある。このアルファチャンネル情報を用いて背景動画に対する合成を行う処理。
     val alphaChannelStreamOverlay = (base: os.Path) =>
       ZIO.attemptBlocking {
-        os.proc(
-          ffmpegCommand,
+        ffmpegProc(
           "-y",
           "-i",
           overlayVideoPath,
@@ -335,8 +334,7 @@ class ConcreteFFmpeg(
     // TODO: Firefoxを使うときにこちらを起動する
     val colorKeyOverlay = (base: os.Path) =>
       ZIO.attemptBlocking {
-        os.proc(
-          ffmpegCommand,
+        ffmpegProc(
           "-y",
           "-i",
           overlayVideoPath,
@@ -373,8 +371,7 @@ class ConcreteFFmpeg(
 
   def zipVideoWithAudio(video: os.Path, audio: os.Path): Task[os.Path] = for {
     _ <- ZIO.attemptBlocking {
-      os.proc(
-        ffmpegCommand,
+      ffmpegProc(
         "-y",
         "-r",
         "30",
@@ -402,8 +399,7 @@ class ConcreteFFmpeg(
       _ <- ZIO.attemptBlocking {
         val sample = 24000 // VOICEVOXに揃えないと伸びてしまう
         val lengthSec = length.toSeconds
-        os.proc(
-          ffmpegCommand,
+        ffmpegProc(
           "-y",
           "-t",
           lengthSec,


### PR DESCRIPTION
## 概要

ブラウザバックエンド（`--screenshot chrome | firefox`）と同様に、ffmpeg の実装を `--ffmpeg local | docker` オプションで切り替えられるようにしました。docker バックエンドを使うと、ホストに ffmpeg をインストールしなくても動画を生成できます。デフォルトは従来どおり local です。

このブランチは zio ブランチ（#253）からの派生です。

## 変更内容

- `infrastructure/DockerFFmpeg.scala`（新規）：`ConcreteFFmpeg` を継承し、`docker run` 経由で ffmpeg / ffprobe を実行する実装を追加しました。
  - イメージは jar に同梱した Dockerfile-ffmpeg から ZLayer 構築時に標準入力経由でビルドします。2回目以降は Docker のレイヤーキャッシュにより高速に完了します。
  - カレントディレクトリをコンテナ内の同一パスにマウントすることで、cutfile 等に記述された絶対パスをコンテナ内でもそのまま解決できるようにしています。
  - コンテナはホストと同じ UID/GID（`--user`）で実行し、生成物が root 所有になることを防ぎます。
  - SELinux 環境でマウントしたファイルへのアクセスが拒否されないよう `--security-opt label=disable` を付与します。`:z` と異なりホスト側ファイルのラベルを書き換えず、SELinux 無効の環境では無視されます。
- `infrastructure/FFmpeg.scala`：コマンドの組み立てを `ffmpegProc` / `ffprobeProc` に抽出し、サブクラスで差し替えられるようにしました。ffmpeg の引数列は変更していません。
- `Design.scala`：`cliLayer` が `FFmpegBackend` を受け取り、docker の場合は ZLayer 構築時にイメージをビルドします。local の場合は従来のリテラル `"ffmpeg"` ではなく設定値 `ffmpeg.command` を参照するようにしました。
- `CliOptions.scala`：`--ffmpeg local | docker` オプションと `FFmpegBackend` を追加しました。
- `reference.conf`：イメージタグの設定 `ffmpeg.dockerImage`（デフォルト `zmm-ffmpeg:latest`）を追加しました。環境変数 `FFMPEG_DOCKER_IMAGE` でも上書きできます。
- `build.sbt`：Dockerfile-ffmpeg を jar のリソースとして同梱するようにしました。
- 未コミットだった Dockerfile-ffmpeg をリポジトリに追加しました。

## 検証

- `sbt test`：16件すべて成功しました。scalafmt / scalafix チェックも通過しています。
- `--ffmpeg docker` を指定したエンドツーエンドの動画生成（VOICEVOX + Firefox + Docker ffmpeg）で 9.56 秒の mp4 が生成されることを確認しました。生成物の所有者はホストユーザーです。
- `--ffmpeg` 未指定（local）でも従来どおり生成できることを回帰確認しました。

## 補足

- docker バックエンドはカレントディレクトリのみをマウントするため、カレントディレクトリ外の素材ファイルは参照できません。素材はプロジェクトディレクトリ配下に置く必要があります。
- ffmpeg の concat demuxer は cutfile 内で参照されているファイルが存在しない場合に「Error opening input file artifacts/bgmCutFile.txt.」のように cutfile 自体のエラーとして報告するため、原因の切り分けが難しいです。cutfile 書き出し前に参照ファイルの存在を検証する改善は別タスクとします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
